### PR TITLE
feat(compat): add SolidStart framework compatibility

### DIFF
--- a/.vitepress/data/compat/frameworks.ts
+++ b/.vitepress/data/compat/frameworks.ts
@@ -124,6 +124,13 @@ export const frameworks: Framework[] = [
     website: "https://svelte.dev/docs/kit",
   },
   {
+    id: "solidstart",
+    name: "SolidStart",
+    category: "meta-framework",
+    icon: "tabler:brand-solidjs", // Using Tabler icon for SolidStart as there is no official icon. TODO: Replace with official icon when available.
+    website: "https://start.solidjs.com/",
+  },
+  {
     id: "tanstack-start",
     name: "TanStack Start",
     category: "meta-framework",

--- a/.vitepress/data/compat/oxfmt.ts
+++ b/.vitepress/data/compat/oxfmt.ts
@@ -101,6 +101,12 @@ export const oxfmtEntries: CompatEntry[] = [
     status: { level: "full", ...needsSvelteCompiler },
   },
   {
+    frameworkId: "solidstart",
+    toolId: "oxfmt",
+    featureId: "format",
+    status: { level: "full" },
+  },
+  {
     frameworkId: "tanstack-start",
     toolId: "oxfmt",
     featureId: "format",

--- a/.vitepress/data/compat/oxlint.ts
+++ b/.vitepress/data/compat/oxlint.ts
@@ -173,6 +173,12 @@ export const oxlintEntries: CompatEntry[] = [
     status: { level: "partial", ...noTemplateLintNote },
   },
   {
+    frameworkId: "solidstart",
+    toolId: "oxlint",
+    featureId: "lint",
+    status: { level: "full", ...solidRulesNote },
+  },
+  {
     frameworkId: "tanstack-start",
     toolId: "oxlint",
     featureId: "lint",


### PR DESCRIPTION
## Summary

- Add SolidStart to the compatibility page
- Match Solid's Oxlint and Oxfmt support levels
- Using the tabler:brand-solidjs icon as a temporary icon since there is still no SolidStart icon available

Closes #1169

## Verification

- `vp check`
- `vp run knip`
- VitePress production build
- `vp test` reports no test files, which is existing repository behavior

## AI usage

Codex helped implement the compatibility data changes. I reviewed and verified the final diff.