### PR TITLE
docs(linter): state that node_modules is skipped via .gitignore

### DIFF
--- a/src/docs/guide/usage/linter/ignore-files.md
+++ b/src/docs/guide/usage/linter/ignore-files.md
@@ -20,6 +20,27 @@ Oxlint automatically ignores:
 
 Hidden files are not automatically ignored.
 
+`node_modules` is not on that list. It is skipped only because a project's `.gitignore` usually matches it. A project without a `.gitignore`, or with one that does not match `node_modules`, gets diagnostics for every lintable file in `node_modules`. Add `node_modules` to `.gitignore`, or add it to `ignorePatterns`:
+
+::: code-group
+
+```json [.oxlintrc.json]
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": ["node_modules/**"]
+}
+```
+
+```ts [oxlint.config.ts]
+import { defineConfig } from "oxlint";
+
+export default defineConfig({
+  ignorePatterns: ["node_modules/**"],
+});
+```
+
+:::
+
 `.gitignore` scopes file discovery. An explicitly named file is still linted even if it is matched by `.gitignore`, while an explicitly named ignored directory is skipped because its contents would need to be discovered.
 
 ## `ignorePatterns`


### PR DESCRIPTION
AI usage disclosure: written with Claude assistance. I reproduced the behavior, read `apps/oxlint/src/walk.rs` and `crates/oxc_config/src/walk.rs`, wrote the change, and verified both suggested fixes.

## Problem

The default-ignores list on this page names `.git`, minified filenames, and `.gitignore` matches, but it does not mention `node_modules`, and `oxlint` has no hardcoded skip for it. `oxfmt` does (`is_ignored_dir` in `apps/oxfmt/src/walk.rs`, with `--with-node-modules` to opt out); `oxlint` does not.

So a project with no `.gitignore` gets a diagnostic for every lintable file under `node_modules`. Reproduced on oxlint 1.81.0:

```sh
mkdir repro && cd repro
npm init -y
npm i -D oxlint@1.81.0 chalk
mkdir src && printf 'const x = 1;\n' > src/a.js
npx oxlint | grep -c node_modules   # 1528
```

Adding `node_modules` to `.gitignore` drops that to zero. The page gives a reader no way to work out why, because it never says the `node_modules` exclusion is `.gitignore`-derived.

This is not a request to change the walker. It documents what the walker already does.

## Change

Two paragraphs and a `code-group` under "Default ignores": where the `node_modules` exclusion comes from, what happens without it, and the two ways to restore it.

Both suggested fixes verified on the repro above, each taking 1528 diagnostics from `node_modules` to zero:

- `node_modules` in `.gitignore`
- `"ignorePatterns": ["node_modules/**"]` with no `.gitignore` present

## Checks

```
pnpm exec vp fmt src/docs/guide/usage/linter/ignore-files.md
pnpm run build     # build complete in 48.71s
```
