### PR TITLE
docs(lsp): add Helix editor configuration docs for oxlint

### DIFF
--- a/src/docs/guide/usage/linter/editors.md
+++ b/src/docs/guide/usage/linter/editors.md
@@ -137,6 +137,23 @@ vim.lsp.enable('oxlint')
 
 - [oxc-project/coc-oxc](https://github.com/oxc-project/coc-oxc)
 
+## Helix
+
+Register oxlint to your `languages.toml` file. The language server expects an active node runtime to work, so one will safely be spawned from your `node_modules folder` via `npx`.
+
+```toml
+[language-server.oxlint]
+command = "npx"
+args = ["oxlint", "--lsp"]
+
+[[language]]
+name = "tsx"
+file-types = ["ts", "tsx"]
+language-servers = [
+  { name = "oxlint" }
+]
+```
+
 ## Other editors
 
 For editors with LSP support (Emacs, Helix, Sublime), you can use `oxlint --lsp` as your language server.


### PR DESCRIPTION
Added configuration instructions for Helix editor to use oxlint.

Running `oxlint` command directly not work. This wasn't completely obvious, forcing me to move back to Neovim where the language server runtime is controlled by the Mason plugin. This was back in my `eslint` days, which doesn't work either.

It is very important to mention in the docs that the `npx` command is primary.